### PR TITLE
fix: 拆分clamp逻辑到blur

### DIFF
--- a/src/el-number-range.vue
+++ b/src/el-number-range.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="el-number-range">
-    <el-input :style="{width}" type="number" v-model.number="minValue"/>
+    <el-input :style="{width}" type="number" v-model.number="minValue" @blur="clampMin" />
     <span class="separator">{{ separator }}</span>
-    <el-input :style="{width}" type="number" v-model.number="maxValue"/>
+    <el-input :style="{width}" type="number" v-model.number="maxValue" @blur="clampMax" />
   </div>
 </template>
 <script>
@@ -52,12 +52,7 @@ export default {
         return this.value[0]
       },
       set(val) {
-        if (this.isNum(val)) {
-          val = this.clamp(val)
-          if (this.isNum(this.maxValue)) val = Math.min(val, this.maxValue)
-        } else {
-          val = undefined
-        }
+        if (val === '') val = undefined
         this.$emit('input', [val, this.maxValue])
       }
     },
@@ -66,24 +61,27 @@ export default {
         return this.value[1]
       },
       set(val) {
-        if (this.isNum(val)) {
-          val = this.clamp(val)
-          if (this.isNum(this.minValue)) val = Math.max(val, this.minValue)
-        } else {
-          val = undefined
-        }
-        /**
-         * 配合v-model使用
-         */
+        if (val === '') val = undefined
         this.$emit('input', [this.minValue, val])
       }
     }
   },
   methods: {
+    clampMin() {
+      if (this.minValue === undefined) return
+      let val = this.clamp(this.minValue)
+      if (this.maxValue !== undefined) val = Math.min(val, this.maxValue)
+      this.$emit('input', [val, this.maxValue])
+    },
+    clampMax() {
+      if (this.maxValue === undefined) return
+      let val = this.clamp(this.maxValue)
+      if (this.minValue !== undefined) val = Math.max(val, this.minValue)
+      this.$emit('input', [this.minValue, val])
+    },
     clamp(val) {
       return Math.max(this.min, Math.min(this.max, val))
-    },
-    isNum: n => typeof n === 'number'
+    }
   }
 }
 </script>


### PR DESCRIPTION
## Why
之前在input阶段做clamp，导致在有最小值时，无法顺畅输入最大值。比如最小值为4，想输入最大值为10时，刚键入1，就立刻变为了4

## How
将clamp逻辑移至blur阶段

## Test
### Before
![Kapture 2019-08-01 at 20 13 03](https://user-images.githubusercontent.com/19591950/62292353-d0a4ca00-b498-11e9-8b73-3f9f03c47326.gif)
### After
![Kapture 2019-08-01 at 20 12 21](https://user-images.githubusercontent.com/19591950/62292357-d3072400-b498-11e9-9710-4ff5c9251de4.gif)

